### PR TITLE
Fix `install: cannot stat 'xgetrootname': No such file or directory`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ CFLAGS := -O3 -Wall -Wextra
 X11CFLAGS := $(shell pkg-config --cflags x11)
 X11LIBS := $(shell pkg-config --libs x11)
 
-all: dwmblocks sigdwmblocks
+all: dwmblocks sigdwmblocks xgetrootname
 
 dwmblocks: dwmblocks.c blocks.h
 	${CC} -o $@ -Wno-missing-field-initializers -Wno-unused-parameter ${CFLAGS} ${X11CFLAGS} $< ${X11LIBS}
@@ -18,7 +18,7 @@ xgetrootname: xgetrootname.c
 	${CC} -o $@ ${CFLAGS} ${X11CFLAGS} $< ${X11LIBS}
 
 clean:
-	rm -f dwmblocks sigdwmblocks
+	rm -f dwmblocks sigdwmblocks xgetrootname
 
 install: all
 	mkdir -p ${DESTDIR}${PREFIX}/bin


### PR DESCRIPTION
A bug was introduced in 87611ea where `make install` tries to install xgetrootname without making it first, causing the following error:
```
install: cannot stat 'xgetrootname': No such file or directory
```